### PR TITLE
Wait for 1 interval before initial build status check

### DIFF
--- a/client.js
+++ b/client.js
@@ -92,6 +92,9 @@ class SisenseV2Client {
 
             // Probe the build status until it finishes, or there are no more retries left
             while (!done && retries > 0) {
+                
+                // Wait for 1 interval
+                await _wait(interval);
 
                 // Get build task's status
                 const buildTask = await this.get(`builds/${buildId}`);
@@ -105,9 +108,8 @@ class SisenseV2Client {
                     return status;
                 }
 
-                // If incomplete, wait for 1 interval and try again
+                // If incomplete, try again
                 retries--;
-                await _wait(interval);
             }
         } catch (e) {
             console.error('error in wait for build');


### PR DESCRIPTION
Checking the build status too quickly after starting the build can generate the false positive error detailed below. Waiting before the initial build status check works around the issue.

`StatusCodeError: 400 - {"title":"Failed to get build process <>","reason":"BE#983754 Data source not found for build id: add53dd8-174e-4d1d-935f-2c4f079e1054"}`
`      at new StatusCodeError (/Users/slpenza/Documents/VSCode/sisense/node_modules/request-promise-core/lib/errors.js:32:15)`
`      at Request.plumbing.callback (/Users/slpenza/Documents/VSCode/sisense/node_modules/request-promise-core/lib/plumbing.js:104:33)`
`      at Request.RP$callback [as _callback] (/Users/slpenza/Documents/VSCode/sisense/node_modules/request-promise-core/lib/plumbing.js:46:31)`
`      at Request.self.callback (/Users/slpenza/Documents/VSCode/sisense/node_modules/request/request.js:185:22)`
`      at Request.emit (events.js:376:20)`
`      at Request.<anonymous> (/Users/slpenza/Documents/VSCode/sisense/node_modules/request/request.js:1161:10)`
`      at Request.emit (events.js:376:20)`
`      at IncomingMessage.<anonymous> (/Users/slpenza/Documents/VSCode/sisense/node_modules/request/request.js:1083:12)`
`      at Object.onceWrapper (events.js:482:28)`
`      at IncomingMessage.emit (events.js:388:22) {`
`      statusCode: 400,`
`      error: {`
`      title: 'Failed to get build process <>',`
`      reason: 'BE#983754 Data source not found for build id: add53dd8-174e-4d1d-935f-2c4f079e1054'`
`      }`